### PR TITLE
[Feat] ScrapFilter 기능 구현

### DIFF
--- a/src/atoms/CaptionDate.tsx
+++ b/src/atoms/CaptionDate.tsx
@@ -12,6 +12,11 @@ export default function CaptionDate({ pub_date }: ICaptionDateProps) {
   return <CaptionDateText>{date}</CaptionDateText>;
 }
 export const CaptionDateText = styled.p`
+  min-width: 95px;
   ${captionFont}
-  color: ${(props) => props.theme.colors.fontGray}
+  display: flex;
+  white-space: nowrap;
+  flex-direction: column;
+  align-items: end;
+  color: ${(props) => props.theme.colors.fontGray};
 `;

--- a/src/atoms/Container.tsx
+++ b/src/atoms/Container.tsx
@@ -14,7 +14,7 @@ export const MobileViewContainer = styled.div`
 export const ContentContainer = styled.section`
   width: 100%;
   height: calc(100vh - ${(props) => props.theme.height.header});
-  padding: 5%;
+  padding: 5% 5% calc(5% + ${(props) => props.theme.height.nav}) 5%;
   background-color: ${(props) => props.theme.colors.bgGray};
   overflow: scroll;
 `;

--- a/src/atoms/FilterInput.tsx
+++ b/src/atoms/FilterInput.tsx
@@ -39,5 +39,9 @@ const FInput = styled.input.attrs((props) => ({
   &:focus {
     outline: none;
     border: 1.5px solid ${(props) => props.theme.colors.pointBlue};
+
+    &::placeholder {
+      color: transparent;
+    }
   }
 `;

--- a/src/atoms/RoundCheckbox.tsx
+++ b/src/atoms/RoundCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import {
   roundBtnStyle,

--- a/src/constant/list.ts
+++ b/src/constant/list.ts
@@ -1,0 +1,75 @@
+export const HEADER_TAB_LIST = [
+  { id: 1, title: '전체 헤드라인' },
+  { id: 2, title: '전체 날짜' },
+  { id: 3, title: '전체 국가' },
+];
+
+export const COUNTRY_FILTER_LIST = [
+  {
+    id: 1,
+    title: '대한민국',
+    countryEN: ['South Korea', 'Republic of Korea'],
+  },
+  {
+    id: 2,
+    title: '중국',
+    countryEN: ['China'],
+  },
+  {
+    id: 3,
+    title: '일본',
+    countryEN: ['Japan'],
+  },
+  {
+    id: 4,
+    title: '미국',
+    countryEN: ['America', 'United States', 'U.S.', 'USA'],
+  },
+  {
+    id: 5,
+    title: '북한',
+    countryEN: ['North Korea'],
+  },
+  {
+    id: 6,
+    title: '러시아',
+    countryEN: ['Russia'],
+  },
+  {
+    id: 7,
+    title: '프랑스',
+    countryEN: ['France'],
+  },
+  {
+    id: 8,
+    title: '영국',
+    countryEN: ['England', 'United Kingdom', 'U.K.'],
+  },
+];
+
+export const ARTICLE_FILTER_CATEGORY = [
+  {
+    id: 1,
+    filter: 'Headline',
+    title: '헤드라인',
+    type: 'text',
+    placeholder: '검색하실 헤드라인을 입력해주세요.',
+    subfilter: null,
+  },
+  {
+    id: 2,
+    filter: 'Date',
+    title: '날짜',
+    type: 'date',
+    placeholder: '날짜를 선택해주세요.',
+    subfilter: null,
+  },
+  {
+    id: 3,
+    filter: 'Country',
+    title: '국가',
+    type: 'checkbox',
+    placeholder: '',
+    subfilter: COUNTRY_FILTER_LIST,
+  },
+];

--- a/src/molecules/FilterCategory.tsx
+++ b/src/molecules/FilterCategory.tsx
@@ -15,20 +15,17 @@ export default function FilterCategory({
 
   let currentPlaceholder = placeholder;
   let activeSubfilter;
-  let currentFilter;
   let setFilter;
 
   if (isModal && filterStore) {
-    const filterKey = Object.keys(filterStore).filter((key) =>
+    const currentFilterKey = Object.keys(filterStore).filter((key) =>
       key.startsWith('current')
     );
-    currentFilter = filterStore[filterKey[0]] as IFilter[];
+    const currentFilter = filterStore[currentFilterKey[0]] as IFilter[];
 
     const index = currentFilter.findIndex((item: IFilter) => item.id === id);
-    if (index !== -1) {
-      currentPlaceholder = currentFilter[index].placeholder;
-      activeSubfilter = currentFilter[index].subfilter;
-    }
+    currentPlaceholder = currentFilter[index].placeholder;
+    activeSubfilter = currentFilter[index].subfilter;
   }
 
   if (filterStore) {

--- a/src/organisms/ArticleCard.tsx
+++ b/src/organisms/ArticleCard.tsx
@@ -17,6 +17,7 @@ export default function ArticleCard({
   source,
   pub_date,
   web_url,
+  keywords,
 }: IArticleCardProps) {
   const [isScrap, setIsScrap] = useState<boolean>(false);
   const { scrapData, setScrapData } = useScrapDataStore();
@@ -44,6 +45,7 @@ export default function ArticleCard({
       pub_date,
       web_url,
       isScrap,
+      keywords,
     };
 
     let updatedScrapData;
@@ -106,10 +108,18 @@ const ArticleScrapBtn = styled.div`
 `;
 
 const CaptionLeft = styled.div`
+  max-width: calc(90% - 95px);
   display: flex;
   gap: 8px;
+
+  :first-child {
+    min-width: 101px;
+  }
 `;
 
 export const CaptionText = styled.p`
   ${captionFont}
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 `;

--- a/src/organisms/FilterModal.tsx
+++ b/src/organisms/FilterModal.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import styled from 'styled-components';
 import ActionBtn from '../atoms/button/ActionBtn';
 import FilterCategory from '../molecules/FilterCategory';
 import { IFilterCategory, IFilterModalProps } from '../type/Filter.type';
 import { ModalContainer } from '../atoms/Container';
-import { subtitleFont } from '../styles/Font.style';
 
 export default function FilterModal({
   category,
@@ -29,7 +27,3 @@ export default function FilterModal({
     </ModalContainer>
   );
 }
-
-const FilterTitle = styled.p`
-  ${subtitleFont}
-`;

--- a/src/pages/ArticleFilter.tsx
+++ b/src/pages/ArticleFilter.tsx
@@ -1,23 +1,36 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import FilterModal from '../organisms/FilterModal';
 import { useArticleFilterState, useModalState } from '../store/useToggleStore';
 import useArticleFilterStore from '../store/useArticleFilterStore';
-import useAppliedArticleFilterStore from '../store/useAppliedArticleFilterStore';
+import {
+  useAppliedArticleFilterStore,
+  useScrapArticleFilterStore,
+} from '../store/useAppliedArticleFilterStore';
+import { ARTICLE_FILTER_CATEGORY } from '../constant/list';
 
 export default function ArticleFilter() {
+  const location = useLocation();
+
   const { isToggle: isModalToggle, setIsToggle: setIsModalToggle } =
     useModalState();
   const { setIsToggle: setIsFilterToggle } = useArticleFilterState();
   const { currentArticleFilter, clearCurrentArticleFilter } =
     useArticleFilterStore();
-
+  const { setAppliedArticleFilter: setScrapArticleFilter } =
+    useScrapArticleFilterStore();
   const { setAppliedArticleFilter } = useAppliedArticleFilterStore();
   const articleFilterStore = useArticleFilterStore();
+
+  const setApplyFilter =
+    location.pathname === '/scrap'
+      ? setScrapArticleFilter
+      : setAppliedArticleFilter;
 
   const applyFilter = () => {
     setIsModalToggle(false);
     setIsFilterToggle(true);
-    setAppliedArticleFilter(currentArticleFilter);
+    setApplyFilter(currentArticleFilter);
     clearCurrentArticleFilter();
   };
 
@@ -31,73 +44,3 @@ export default function ArticleFilter() {
     />
   );
 }
-
-export const COUNTRY_FILTER_LIST = [
-  {
-    id: 1,
-    title: '대한민국',
-    countryEN: ['South Korea', 'Republic of Korea'],
-  },
-  {
-    id: 2,
-    title: '중국',
-    countryEN: ['China'],
-  },
-  {
-    id: 3,
-    title: '일본',
-    countryEN: ['Japan'],
-  },
-  {
-    id: 4,
-    title: '미국',
-    countryEN: ['America', 'United States', 'U.S.', 'USA'],
-  },
-  {
-    id: 5,
-    title: '북한',
-    countryEN: ['North Korea'],
-  },
-  {
-    id: 6,
-    title: '러시아',
-    countryEN: ['Russia'],
-  },
-  {
-    id: 7,
-    title: '프랑스',
-    countryEN: ['France'],
-  },
-  {
-    id: 8,
-    title: '영국',
-    countryEN: ['England', 'United Kingdom', 'U.K.'],
-  },
-];
-
-const ARTICLE_FILTER_CATEGORY = [
-  {
-    id: 1,
-    filter: 'Headline',
-    title: '헤드라인',
-    type: 'text',
-    placeholder: '검색하실 헤드라인을 입력해주세요.',
-    subfilter: null,
-  },
-  {
-    id: 2,
-    filter: 'Date',
-    title: '날짜',
-    type: 'date',
-    placeholder: '날짜를 선택해주세요.',
-    subfilter: null,
-  },
-  {
-    id: 3,
-    filter: 'Country',
-    title: '국가',
-    type: 'checkbox',
-    placeholder: '',
-    subfilter: COUNTRY_FILTER_LIST,
-  },
-];

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import ArticleList from '../templates/ArticleList';
 import {
@@ -7,17 +7,31 @@ import {
 } from '../api/articleSearchAPI';
 import NoData from '../molecules/NoData';
 import { useArticleFilterState } from '../store/useToggleStore';
-import useAppliedArticleFilterStore from '../store/useAppliedArticleFilterStore';
+import useArticleFilterStore from '../store/useArticleFilterStore';
+import {
+  useAppliedArticleFilterStore,
+  useScrapArticleFilterStore,
+} from '../store/useAppliedArticleFilterStore';
 
 export default function HomeScrap() {
   const { isToggle: isFilterToggle } = useArticleFilterState();
+  const { setIsToggle: setIsFilterToggle } = useArticleFilterState();
+  const { clearAppliedArticleFilter: clearScrapArticleFilter } =
+    useScrapArticleFilterStore();
   const { appliedArticleFilter } = useAppliedArticleFilterStore();
+  const { clearCurrentArticleFilter } = useArticleFilterStore();
 
   const { data: allArticleData } = useGetNytArticle();
   const { data: filteredData } = useGetFilteredArticle(appliedArticleFilter);
 
   const data = isFilterToggle ? filteredData : allArticleData;
   const articleArr = data?.response?.docs || [];
+
+  useEffect(() => {
+    clearScrapArticleFilter();
+    clearCurrentArticleFilter();
+    setIsFilterToggle(false);
+  }, []);
 
   return articleArr.length > 0 ? (
     <ArticleList articleArr={articleArr} />

--- a/src/pages/Scrap.tsx
+++ b/src/pages/Scrap.tsx
@@ -2,11 +2,46 @@ import React, { useEffect, useState } from 'react';
 import ArticleList from '../templates/ArticleList';
 import NoData from '../molecules/NoData';
 import useScrapDataStore from '../store/useScrapDataStore';
+import useArticleFilterStore from '../store/useArticleFilterStore';
+import { useArticleFilterState } from '../store/useToggleStore';
+import {
+  useAppliedArticleFilterStore,
+  useScrapArticleFilterStore,
+} from '../store/useAppliedArticleFilterStore';
+import { IArticleCardProps } from '../type/Article.type';
+import scrapFilter from '../utils/scrapFilter';
 
 export default function Scrap() {
+  const [data, setData] = useState<IArticleCardProps[]>([]);
   const { scrapData } = useScrapDataStore();
+  const { isToggle: isFilterToggle, setIsToggle: setIsFilterToggle } =
+    useArticleFilterState();
+  const {
+    appliedArticleFilter: scrapArticleFilter,
+    clearAppliedArticleFilter: clearScrapArticleFilter,
+  } = useScrapArticleFilterStore();
+  const { clearAppliedArticleFilter } = useAppliedArticleFilterStore();
+  const { clearCurrentArticleFilter } = useArticleFilterStore();
 
-  const articleArr = scrapData || [];
+  const articleArr = data;
+
+  useEffect(() => {
+    clearAppliedArticleFilter();
+    clearCurrentArticleFilter();
+    setIsFilterToggle(false);
+    setData(scrapData);
+  }, []);
+
+  useEffect(() => {
+    setData(scrapData);
+  }, [scrapData]);
+
+  useEffect(() => {
+    if (isFilterToggle) {
+      const filteredData = scrapFilter(scrapData, scrapArticleFilter);
+      setData(filteredData);
+    }
+  }, [scrapArticleFilter]);
 
   return articleArr.length > 0 ? (
     <ArticleList articleArr={articleArr} />

--- a/src/store/useAppliedArticleFilterStore.ts
+++ b/src/store/useAppliedArticleFilterStore.ts
@@ -17,20 +17,23 @@ const appliedInitialFilter = [
   { id: 3, title: 'country', placeholder: '', subfilter: [] },
 ];
 
-const useAppliedArticleFilterStore = create<IApplyFilter>((set) => ({
-  appliedArticleFilter: appliedInitialFilter,
-  setAppliedArticleFilter: (newValue: IFilter[]) => {
-    set((state) => {
-      const updatedState = { ...state };
-      updatedState.appliedArticleFilter = newValue;
-      return updatedState;
-    });
-  },
-  clearAppliedArticleFilter: () => {
-    set(() => {
-      return { appliedArticleFilter: [] };
-    });
-  },
-}));
+const createAppliedArticleFilterStore = () =>
+  create<IApplyFilter>((set) => ({
+    appliedArticleFilter: appliedInitialFilter,
+    setAppliedArticleFilter: (newValue: IFilter[]) => {
+      set((state) => {
+        return {
+          appliedArticleFilter: newValue,
+        };
+      });
+    },
+    clearAppliedArticleFilter: () => {
+      set(() => {
+        return { appliedArticleFilter: appliedInitialFilter };
+      });
+    },
+  }));
 
-export default useAppliedArticleFilterStore;
+export const useAppliedArticleFilterStore = createAppliedArticleFilterStore();
+
+export const useScrapArticleFilterStore = createAppliedArticleFilterStore();

--- a/src/store/useArticleFilterStore.ts
+++ b/src/store/useArticleFilterStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { ICurrentFilter, IFilter, ISubfilter } from '../type/Filter.type';
+import isWhitespace from '../utils/isWhitespace';
 
 export interface IArticleFilter extends ICurrentFilter {
   currentArticleFilter: IFilter[];
@@ -20,12 +21,8 @@ const currentInitialFilter = [
   { id: 3, title: 'country', placeholder: '', subfilter: [] },
 ];
 
-const whitespacePattern = /^\s*$/;
-const isWhitespace = (text: string) => {
-  return whitespacePattern.test(text);
-};
-
 const useArticleFilterStore = create<IArticleFilter>((set) => ({
+  initialFilter: currentInitialFilter,
   currentArticleFilter: currentInitialFilter,
   setHeadlineFilter: (newValue: string) => {
     set((state) => {
@@ -34,7 +31,9 @@ const useArticleFilterStore = create<IArticleFilter>((set) => ({
         currentArticleFilter: [
           {
             ...state.currentArticleFilter[0],
-            placeholder: isWhitespace(newValue) ? '' : newValue,
+            placeholder: isWhitespace(newValue)
+              ? currentInitialFilter[0].placeholder
+              : newValue,
           },
           ...state.currentArticleFilter.slice(1),
         ],
@@ -49,7 +48,9 @@ const useArticleFilterStore = create<IArticleFilter>((set) => ({
           ...state.currentArticleFilter.slice(0, 1),
           {
             ...state.currentArticleFilter[1],
-            placeholder: isWhitespace(newValue) ? '' : newValue,
+            placeholder: isWhitespace(newValue)
+              ? currentInitialFilter[1].placeholder
+              : newValue,
           },
           ...state.currentArticleFilter.slice(2),
         ],
@@ -84,35 +85,16 @@ const useArticleFilterStore = create<IArticleFilter>((set) => ({
       };
     });
   },
-  //   set((state) => {
-  //     const updatedState = { ...state };
-  //     const updatedSubfilter =
-  //       updatedState.currentArticleFilter[2].subfilter?.slice();
-
-  //     const index = updatedSubfilter?.findIndex(
-  //       (item) => item?.id === newValue.id
-  //     );
-
-  //     if (index !== undefined && index !== -1) {
-  //       updatedSubfilter?.splice(index, 1);
-  //     } else {
-  //       updatedSubfilter?.push(newValue);
-  //     }
-
-  //     updatedState.currentArticleFilter[2].subfilter = updatedSubfilter;
-  //     return { ...state };
-  //   });
-  // },
   setCurrentArticleFilter: (newValue: IFilter[]) => {
     set(() => {
       return {
-        newValue,
+        currentArticleFilter: newValue,
       };
     });
   },
   clearCurrentArticleFilter: () => {
     set(() => {
-      return { currentInitialFilter };
+      return { currentArticleFilter: currentInitialFilter };
     });
   },
 }));

--- a/src/templates/ArticleList.tsx
+++ b/src/templates/ArticleList.tsx
@@ -19,6 +19,7 @@ export default function ArticleList({
             source={el.source}
             pub_date={el.pub_date}
             web_url={el.web_url}
+            keywords={el.keywords}
           />
         );
       })}

--- a/src/type/Article.type.ts
+++ b/src/type/Article.type.ts
@@ -16,7 +16,6 @@ interface IMeta {
 export interface IArticle extends IArticleCardProps {
   abstract: string;
   document_type: string; // "article"
-  keywords: IKeywords[];
   lead_paragraph: string;
   multimedia: IMultimedia[];
   news_desk: string; // 'OpEd'
@@ -53,6 +52,8 @@ interface IKeywords {
   value: string; // 'Social Media'
 }
 
+// {name: 'glocations', value: 'United States', rank: 1, major: 'N'}
+
 interface IMultimedia {
   caption: string | null;
   credit: string | null;
@@ -68,7 +69,7 @@ interface IMultimedia {
   subtype: string;
   type: string;
   url: string;
-  width: 600;
+  width: number;
 }
 
 export interface IArticleCardProps extends ICaptionDateProps {
@@ -76,6 +77,7 @@ export interface IArticleCardProps extends ICaptionDateProps {
   headline: IHeadline;
   source: string; // 'The New York Times'
   web_url: string;
+  keywords: IKeywords[];
 }
 
 export interface ICaptionDateProps {

--- a/src/utils/filterQuery.ts
+++ b/src/utils/filterQuery.ts
@@ -1,6 +1,5 @@
-import React from 'react';
-import { COUNTRY_FILTER_LIST } from '../pages/ArticleFilter';
-import useAppliedArticleFilterStore from '../store/useAppliedArticleFilterStore';
+import { ARTICLE_FILTER_CATEGORY, COUNTRY_FILTER_LIST } from '../constant/list';
+import { useAppliedArticleFilterStore } from '../store/useAppliedArticleFilterStore';
 
 export default function filterQuery() {
   const { appliedArticleFilter } = useAppliedArticleFilterStore();
@@ -25,16 +24,18 @@ export default function filterQuery() {
 
   if (
     filteredHeadline &&
-    filteredHeadline !== '검색하실 헤드라인을 입력해주세요.'
+    filteredHeadline !== ARTICLE_FILTER_CATEGORY[0].placeholder
   ) {
     filterQueryArr.push(`headline:("${filteredHeadline}")`);
   }
-  if (filteredDate && filteredDate !== '날짜를 선택해주세요.') {
+  if (filteredDate && filteredDate !== ARTICLE_FILTER_CATEGORY[1].placeholder) {
     filterQueryArr.push(`pub_date:("${filteredDate}")`);
   }
-  filterQueryArr.push(`(${glocations})`);
-
-  const filterQueryString = `fq=${filterQueryArr.join(' AND ')}`;
+  if (glocations) {
+    filterQueryArr.push(`(${glocations})`);
+  }
+  const filterQueryString =
+    filterQueryArr.length > 0 ? `fq=${filterQueryArr.join(' AND ')}` : '';
 
   return filterQueryString;
 }

--- a/src/utils/isWhitespace.ts
+++ b/src/utils/isWhitespace.ts
@@ -1,0 +1,6 @@
+const whitespacePattern = /^\s*$/;
+const isWhitespace = (text: string) => {
+  return whitespacePattern.test(text);
+};
+
+export default isWhitespace;

--- a/src/utils/scrapFilter.ts
+++ b/src/utils/scrapFilter.ts
@@ -1,0 +1,59 @@
+import { ARTICLE_FILTER_CATEGORY, COUNTRY_FILTER_LIST } from '../constant/list';
+import { IArticleCardProps } from '../type/Article.type';
+import { IFilter } from '../type/Filter.type';
+import isWhitespace from './isWhitespace';
+
+const scrapFilter = (
+  scrapData: IArticleCardProps[],
+  scrapArticleFilter: IFilter[]
+) => {
+  const filteredHeadline =
+    isWhitespace(scrapArticleFilter[0].placeholder) ||
+    scrapArticleFilter[0].placeholder === ARTICLE_FILTER_CATEGORY[0].placeholder
+      ? null
+      : scrapArticleFilter[0].placeholder;
+
+  const filteredDate =
+    isWhitespace(scrapArticleFilter[1].placeholder) ||
+    scrapArticleFilter[1].placeholder === ARTICLE_FILTER_CATEGORY[1].placeholder
+      ? null
+      : scrapArticleFilter[1].placeholder;
+
+  const filteredCountryArr = scrapArticleFilter[2]?.subfilter;
+  const filteredCountryIdArr = filteredCountryArr?.map((country) => country.id);
+
+  const filteredCountryEN = COUNTRY_FILTER_LIST.filter(
+    (item) => filteredCountryIdArr?.includes(item.id)
+  )
+    .map((item) => item.countryEN)
+    .flat()
+    .map((item) => item.toLowerCase());
+
+  const filteredData = scrapData.reduce((acc, cur) => {
+    const headlineCondition = filteredHeadline
+      ? cur.headline.main.toLowerCase().includes(filteredHeadline)
+      : true;
+
+    const dateCondition = filteredDate
+      ? cur.pub_date.includes(filteredDate)
+      : true;
+
+    const glocationArr = cur.keywords
+      ?.filter((item) => item.name === 'glocations')
+      .map((item) => item.value.toLowerCase());
+
+    const countryCondition =
+      Array.isArray(filteredCountryEN) && filteredCountryEN.length > 0
+        ? glocationArr.some((value) => filteredCountryEN.includes(value))
+        : true;
+
+    if (headlineCondition && dateCondition && countryCondition) {
+      acc.push(cur);
+    }
+    return acc;
+  }, [] as IArticleCardProps[]);
+
+  return filteredData;
+};
+
+export default scrapFilter;


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 레이아웃 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표
1. Home 및 Scrap 페이지 필터 분리
2. ScrapFilter 기능 구현
<br />

## :: 구현 사항 설명
1. Home 및 Scrap 페이지 필터 분리
- useLocation() 사용하여 pathname 에 따라 필터 분리
- Home 페이지에서 열린 필터에서 입력된 값은 useArticleFilterStore.currentArticleFilter 에 저장
- Scrap 페이지에서 열린 필터에서 입력된 값은 useScrapArticleFilterStore.appliedArticleFilter 에 저장
- 필터 적용하기 버튼을 클릭하면 useAppliedArticleFilterStore.appliedArticleFilter 에 저장
<br />

2. ScrapFilter 기능 구현
- country (glocations) 필터를 위해 keywords 를 IArticleCardProps 에 추가
- .reduce() 메서드 사용 / scrapData 의 데이터를 돌면서 조건을 하나씩 테스트, 모든 조건 (useScrapArticleFilterStore.appliedArticleFilter) 을 만족시키는 데이터를 반환하여 렌더링
<br />

## :: 코드 기록
<br />

## :: 알게 된 점
- .reduce() 메서드로 여러 개의 검색 조건 필터링!
<br />

## :: 기타
<br />
